### PR TITLE
Update Dockerfile

### DIFF
--- a/motioneye/Dockerfile
+++ b/motioneye/Dockerfile
@@ -12,7 +12,7 @@ COPY requirements.txt /tmp/
 RUN \
     apk add --no-cache --virtual .build-dependencies \
         curl-dev=7.67.0-r0 \
-        gcc=9.2.0-r4 \
+        gcc=9.3.0-r0 \
         jpeg-dev=8-r6 \
         musl-dev=1.1.24-r2 \
         py2-pip=18.1-r0 \
@@ -20,7 +20,7 @@ RUN \
     \
     && apk add --no-cache \
         cifs-utils=6.9-r1 \
-        ffmpeg=4.2.1-r3 \
+        ffmpeg=4.2.4-r0 \
         libcurl=7.67.0-r0 \
         libjpeg=8-r6 \
         mosquitto-clients=1.6.8-r0 \


### PR DESCRIPTION
Updated versions of depencies for:

 - gcc
 - ffmpeg

# Proposed Changes

I could not build the docker file anymore, because it looks like alpine has updated some of their packages. I've just updated the package version for gcc and ffmpeg.

## Related Issues

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/